### PR TITLE
Feature: expose event callback setter in subscription, service, client and timer

### DIFF
--- a/rclpy/rclpy/impl/_rclpy_pybind11.pyi
+++ b/rclpy/rclpy/impl/_rclpy_pybind11.pyi
@@ -195,6 +195,12 @@ class Client(Destroyable, Generic[SrvRequestT, SrvResponseT]):
     def get_logger_name(self) -> str:
         """Get the name of the logger associated with the node of the client."""
 
+    def set_on_new_response_callback(self, callback: Callable[[int], None]) -> None:
+        """Set the on new response callback function for the client."""
+
+    def clear_on_new_response_callback(self) -> None:
+        """Clear the on new response callback function for the client."""
+
 
 class Context(Destroyable):
 
@@ -285,6 +291,12 @@ class Service(Destroyable, Generic[SrvRequestT, SrvResponseT]):
 
     def get_logger_name(self) -> str:
         """Get the name of the logger associated with the node of the service."""
+
+    def set_on_new_request_callback(self, callback: Callable[[int], None]) -> None:
+        """Set the on new request callback function for the service."""
+
+    def clear_on_new_request_callback(self) -> None:
+        """Clear the on new request callback function for the service."""
 
 
 class TypeDescriptionService(Destroyable):
@@ -578,6 +590,12 @@ class Timer(Destroyable):
     def is_timer_canceled(self) -> bool:
         """Check if a timer is canceled."""
 
+    def set_on_reset_callback(self, callback: Callable[[int], None]) -> None:
+        """Set the on reset callback function for the timer."""
+
+    def clear_on_reset_callback(self) -> None:
+        """Clear the on reset callback function for the timer."""
+
 
 class Subscription(Destroyable, Generic[MsgT]):
 
@@ -599,6 +617,12 @@ class Subscription(Destroyable, Generic[MsgT]):
 
     def get_publisher_count(self) -> int:
         """Count the publishers from a subscription."""
+
+    def set_on_new_message_callback(self, callback: Callable[[int], None]) -> None:
+        """Set the on new message callback function for the subscription."""
+
+    def clear_on_new_message_callback(self) -> None:
+        """Clear the on new message callback function for the subscription."""
 
 
 class rcl_time_point_t:

--- a/rclpy/src/rclpy/client.hpp
+++ b/rclpy/src/rclpy/client.hpp
@@ -16,6 +16,7 @@
 #define RCLPY__CLIENT_HPP_
 
 #include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
 
 #include <rcl/client.h>
 #include <rcl/service_introspection.h>
@@ -120,10 +121,20 @@ public:
   const char *
   get_logger_name() const;
 
+  void
+  set_on_new_response_callback(std::function<void(size_t)> callback);
+
+  void
+  clear_on_new_response_callback();
+
 private:
   Node node_;
+  std::function<void(size_t)> on_new_response_callback_{nullptr};
   std::shared_ptr<rcl_client_t> rcl_client_;
   rosidl_service_type_support_t * srv_type_;
+
+  void
+  set_callback(rcl_event_callback_t callback, const void * user_data);
 };
 
 /// Define a pybind11 wrapper for an rclpy::Client

--- a/rclpy/src/rclpy/events_executor/rcl_support.cpp
+++ b/rclpy/src/rclpy/events_executor/rcl_support.cpp
@@ -26,7 +26,13 @@ namespace events_executor
 extern "C" void RclEventCallbackTrampoline(const void * user_data, size_t number_of_events)
 {
   const auto cb = reinterpret_cast<const std::function<void(size_t)> *>(user_data);
-  (*cb)(number_of_events);
+  try {
+    (*cb)(number_of_events);
+  } catch (const std::exception & e) {
+    // Catch and print any exception to avoid propagation to c code
+    std::fprintf(stderr, "%s\n", e.what());
+    std::terminate();
+  }
 }
 
 RclCallbackManager::RclCallbackManager(EventsQueue * events_queue)

--- a/rclpy/src/rclpy/service.hpp
+++ b/rclpy/src/rclpy/service.hpp
@@ -16,6 +16,7 @@
 #define RCLPY__SERVICE_HPP_
 
 #include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
 
 #include <rcl/service.h>
 #include <rcl/service_introspection.h>
@@ -125,10 +126,20 @@ public:
   void
   destroy() override;
 
+  void
+  set_on_new_request_callback(std::function<void(size_t)> callback);
+
+  void
+  clear_on_new_request_callback();
+
 private:
   Node node_;
+  std::function<void(size_t)> on_new_request_callback_{nullptr};
   std::shared_ptr<rcl_service_t> rcl_service_;
   rosidl_service_type_support_t * srv_type_;
+
+  void
+  set_callback(rcl_event_callback_t callback, const void * user_data);
 };
 
 /// Define a pybind11 wrapper for an rclpy::Service

--- a/rclpy/src/rclpy/subscription.hpp
+++ b/rclpy/src/rclpy/subscription.hpp
@@ -16,6 +16,7 @@
 #define RCLPY__SUBSCRIPTION_HPP_
 
 #include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
 
 #include <rcl/subscription.h>
 
@@ -105,9 +106,19 @@ public:
   void
   destroy() override;
 
+  void
+  set_on_new_message_callback(std::function<void(size_t)> callback);
+
+  void
+  clear_on_new_message_callback();
+
 private:
   Node node_;
+  std::function<void(size_t)> on_new_message_callback_{nullptr};
   std::shared_ptr<rcl_subscription_t> rcl_subscription_;
+
+  void
+  set_callback(rcl_event_callback_t callback, const void * user_data);
 };
 /// Define a pybind11 wrapper for an rclpy::Subscription
 void define_subscription(py::object module);

--- a/rclpy/src/rclpy/timer.hpp
+++ b/rclpy/src/rclpy/timer.hpp
@@ -17,6 +17,7 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/functional.h>
 
 #include <rcl/timer.h>
 
@@ -145,10 +146,20 @@ public:
   /// Force an early destruction of this object
   void destroy() override;
 
+  void
+  set_on_reset_callback(std::function<void(size_t)> callback);
+
+  void
+  clear_on_reset_callback();
+
 private:
   Context context_;
   Clock clock_;
+  std::function<void(size_t)> on_reset_callback_{nullptr};
   std::shared_ptr<rcl_timer_t> rcl_timer_;
+
+  void
+  set_callback(rcl_event_callback_t callback, const void * user_data);
 };
 
 /// Define a pybind11 wrapper for an rcl_timer_t

--- a/rclpy/test/test_service.py
+++ b/rclpy/test/test_service.py
@@ -15,6 +15,7 @@
 from typing import Generator
 from typing import List
 from typing import Optional
+from unittest.mock import Mock
 
 import pytest
 
@@ -116,3 +117,16 @@ def test_service_context_manager() -> None:
         with node.create_service(
                 srv_type=Empty, srv_name='empty_service', callback=lambda _, _1: None) as srv:
             assert srv.service_name == '/empty_service'
+
+
+def test_set_on_new_request_callback(test_node) -> None:
+    cli = test_node.create_client(Empty, '/service')
+    srv = test_node.create_service(Empty, '/service', lambda req, res: res)
+    cb = Mock()
+    srv.handle.set_on_new_request_callback(cb)
+    cb.assert_not_called()
+    cli.call_async(Empty.Request())
+    cb.assert_called_once_with(1)
+    srv.handle.clear_on_new_request_callback()
+    cli.call_async(Empty.Request())
+    cb.assert_called_once()

--- a/rclpy/test/test_subscription.py
+++ b/rclpy/test/test_subscription.py
@@ -15,6 +15,7 @@
 import time
 from typing import List
 from typing import Optional
+from unittest.mock import Mock
 
 import pytest
 
@@ -176,3 +177,21 @@ def test_subscription_publisher_count() -> None:
     sub.destroy()
 
     node.destroy_node()
+
+
+def test_on_new_message_callback(test_node) -> None:
+    topic_name = '/topic'
+    cb = Mock()
+    sub = test_node.create_subscription(
+        msg_type=Empty,
+        topic=topic_name,
+        qos_profile=10,
+        callback=cb)
+    pub = test_node.create_publisher(Empty, topic_name, 10)
+    sub.handle.set_on_new_message_callback(cb)
+    cb.assert_not_called()
+    pub.publish(Empty())
+    cb.assert_called_once_with(1)
+    sub.handle.clear_on_new_message_callback()
+    pub.publish(Empty())
+    cb.assert_called_once()


### PR DESCRIPTION
Recreated from original PR: https://github.com/ros2/rclpy/pull/1496

Part of #1399.
- Expose set_on_new_message_callback and clear_on_new_message_callback for subscription.
- Expose set_on_new_request_callback and clear_on_new_request_callback for service.
- Expose set_on_new_response_callback and clear_on_new_response_callback for client.
- Expose set_on_reset_callback and clear_on_reset_callback for timer.